### PR TITLE
Adjust the window if it is out of screen bounds on Y axis

### DIFF
--- a/Autocomplete/Sources/Controllers/ZPLSuggestionWindowController.m
+++ b/Autocomplete/Sources/Controllers/ZPLSuggestionWindowController.m
@@ -269,18 +269,24 @@ static const NSSize ZPLSuggestionWindowControllerMaximumWindowSize = {.width = 1
     NSRect positioningTextViewRect = [positioningTextView convertRect:characterRect toView:nil];
     NSRect rect = [positioningTextView.window convertRectToScreen:positioningTextViewRect];
 
-    rect.origin.y = rect.origin.y - windowHeight - ZPLSuggestionWindowControllerMargin;
     rect.size.width = ZPLSuggestionWindowControllerMaximumWindowSize.width;
     rect.size.height = windowHeight;
 
-    CGFloat screenMaxX = NSMaxX(positioningTextView.window.screen.visibleFrame);
+    NSRect screenVisibleFrame = positioningTextView.window.screen.visibleFrame;
     CGFloat minX = ZPLSuggestionWindowControllerMargin;
-    CGFloat maxX = screenMaxX - ZPLSuggestionWindowControllerMargin;
+    CGFloat maxX = NSMaxX(screenVisibleFrame) - ZPLSuggestionWindowControllerMargin;
 
     if (NSMaxX(rect) > maxX) {
         rect.origin.x = maxX - rect.size.width;
     } else if (NSMinX(rect) < minX) {
         rect.origin.x = minX;
+    }
+
+    CGFloat rectOriginY = rect.origin.y - windowHeight - ZPLSuggestionWindowControllerMargin;
+    if (rectOriginY < NSMinY(screenVisibleFrame)) {
+        rect.origin.y = rect.origin.y + positioningTextViewRect.size.height;
+    } else {
+        rect.origin.y = rectOriginY;
     }
 
     [self.window setFrame:rect display:NO];

--- a/Autocomplete/Sources/Controllers/ZPLSuggestionWindowController.m
+++ b/Autocomplete/Sources/Controllers/ZPLSuggestionWindowController.m
@@ -273,7 +273,7 @@ static const NSSize ZPLSuggestionWindowControllerMaximumWindowSize = {.width = 1
     rect.size.width = ZPLSuggestionWindowControllerMaximumWindowSize.width;
     rect.size.height = windowHeight;
 
-    CGFloat screenMaxX = NSMaxX(positioningTextView.window.screen.frame);
+    CGFloat screenMaxX = NSMaxX(positioningTextView.window.screen.visibleFrame);
     CGFloat minX = ZPLSuggestionWindowControllerMargin;
     CGFloat maxX = screenMaxX - ZPLSuggestionWindowControllerMargin;
 


### PR DESCRIPTION
I've also changed `screen.frame` as `screen.visibleFrame` to take the area currently occupied by the dock and menu bar into account.